### PR TITLE
Update timeout to 30 mins for db operations

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -221,7 +221,7 @@ variable "labels_read_replica" {
 variable "db_timeout" {
   description = "How long a database operation is allowed to take before being considered a failure."
   type        = string
-  default     = "15m"
+  default     = "30m"
 }
 
 variable "sql_proxy_user_groups" {


### PR DESCRIPTION
Update time out to 30 mins as that is the value followed by google_sql_database_instance terraform resource.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#timeouts